### PR TITLE
fix: 도서 조회 시 createdAt, updatedAt 값 null 반환 문제 해결 

### DIFF
--- a/src/main/java/com/walkbook/demo/controller/BookController.java
+++ b/src/main/java/com/walkbook/demo/controller/BookController.java
@@ -20,7 +20,6 @@ public class BookController {
     private final BookService bookService;
     private final CategoryService categoryService;
 
-
     @GetMapping("/{bookId}")
     public ResponseEntity<ApiResponse<BookResponseDto>> getBook(@PathVariable Long bookId) {
         Book book = bookService.getBook(bookId);
@@ -29,7 +28,7 @@ public class BookController {
         );
     }
 
-    @GetMapping
+    @GetMapping("")
     public ResponseEntity<ApiResponse<List<BookResponseDto>>> getAllBooks() {
         return ResponseEntity.ok(
                 ResponseUtil.success("도서 목록 조회 성공", bookService.getAllBooks())

--- a/src/main/java/com/walkbook/demo/controller/BookController.java
+++ b/src/main/java/com/walkbook/demo/controller/BookController.java
@@ -5,7 +5,6 @@ import com.walkbook.demo.domain.Category;
 import com.walkbook.demo.dto.request.BookRequestDto;
 import com.walkbook.demo.dto.response.ApiResponse;
 import com.walkbook.demo.dto.response.BookResponseDto;
-import com.walkbook.demo.dto.response.CategoryResponseDto;
 import com.walkbook.demo.service.BookService;
 import com.walkbook.demo.service.CategoryService;
 import com.walkbook.demo.util.ResponseUtil;

--- a/src/main/java/com/walkbook/demo/controller/CategoryController.java
+++ b/src/main/java/com/walkbook/demo/controller/CategoryController.java
@@ -7,7 +7,6 @@ import com.walkbook.demo.util.ResponseUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.*;
 
 @RestController
@@ -17,7 +16,7 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     // 전체 조회
-    @GetMapping
+    @GetMapping("")
     public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> getAllCategories() {
         List<CategoryResponseDto> categories = categoryService.getAllCategories();
         return ResponseEntity.ok(

--- a/src/main/java/com/walkbook/demo/domain/Book.java
+++ b/src/main/java/com/walkbook/demo/domain/Book.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @AllArgsConstructor

--- a/src/main/java/com/walkbook/demo/dto/request/CategoryRequestDto.java
+++ b/src/main/java/com/walkbook/demo/dto/request/CategoryRequestDto.java
@@ -1,4 +1,5 @@
 package com.walkbook.demo.dto.request;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/walkbook/demo/error/ExceptionCode.java
+++ b/src/main/java/com/walkbook/demo/error/ExceptionCode.java
@@ -1,6 +1,5 @@
 package com.walkbook.demo.error;
 
-
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/walkbook/demo/service/BookServiceImpl.java
+++ b/src/main/java/com/walkbook/demo/service/BookServiceImpl.java
@@ -47,6 +47,8 @@ public class BookServiceImpl implements BookService{
                 .coverUrl(book.getCoverUrl())
                 .publicationTime(book.getPublicationTime())
                 .categoryId(book.getCategory().getCategoryId())
+                .createdAt(book.getCreatedAt())
+                .updatedAt(book.getUpdatedAt())
                 .build();
     }
 


### PR DESCRIPTION
### 📌 원인 
Book 도서 상세 정보 반환 API에서 createdAt, updatedAt 값이 null로 반환되는 현상이 있었습니다.
확인해보니 convertToDto()에서 날짜 정보만 빼고 매핑되어있길래 수정했습니다...  

### ✅ Postman 테스트 결과 
<img width="359" alt="image" src="https://github.com/user-attachments/assets/126a8476-36f0-427f-be68-5010e17abc60" />
