### PR TITLE
fix: 이미지 url 길이 제한 수정 

### DIFF
--- a/src/main/java/com/walkbook/demo/domain/Book.java
+++ b/src/main/java/com/walkbook/demo/domain/Book.java
@@ -36,6 +36,7 @@ public class Book {
     @Column(nullable = false)
     private String description;
 
+    @Column(columnDefinition = "TEXT")
     private String coverUrl;
 
     @Column(nullable = false)


### PR DESCRIPTION
### 📌 수정사항 
- chatGPT가 생성한 이미지 url 길이가 너무 길어서 h2콘솔에 저장시 길이 제한을 넘어버리는 문제가 있음. 
- 따라서 coverUrl 의 컬럼 속성을 db 에서 저장할 수 있는 문자열 최대치인    ` @Column(columnDefinition = "TEXT")` 으로 설정 
- 그러나, application.yml에 ddl-auto가 update로 되어있지만 column의 
타입이 바뀌지 않기 때문에 이전에 서버를 실행했더라면 
`ALTER TABLE book ALTER COLUMN cover_url TEXT;` 을 직접 수행해주기  