### PR TITLE
feat : 카테고리 테스트 코드 추가

### DIFF
--- a/src/main/java/com/walkbook/demo/error/BusinessException.java
+++ b/src/main/java/com/walkbook/demo/error/BusinessException.java
@@ -9,7 +9,7 @@ public class BusinessException extends RuntimeException {
     private final ExceptionCode exceptionCode;
 
     public BusinessException(ExceptionCode exceptionCode){
-
+        super(exceptionCode.getMessage());
         this.exceptionCode = exceptionCode;
     }
 

--- a/src/test/java/com/walkbook/demo/controller/CategoryControllerTest.java
+++ b/src/test/java/com/walkbook/demo/controller/CategoryControllerTest.java
@@ -1,0 +1,67 @@
+package com.walkbook.demo.controller;
+
+import com.walkbook.demo.dto.response.CategoryResponseDto;
+import com.walkbook.demo.service.CategoryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CategoryController.class)
+@Import(CategoryControllerTest.MockConfig.class)
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @TestConfiguration
+    static class MockConfig {
+        @Bean
+        public CategoryService categoryService() {
+            return Mockito.mock(CategoryService.class);
+        }
+    }
+
+    @Test
+    @DisplayName("카테고리 전체 조회 성공")
+    void getAllCategories() throws Exception {
+        List<CategoryResponseDto> list = List.of(
+                new CategoryResponseDto(1L, "문학", "문학 설명")
+        );
+
+        given(categoryService.getAllCategories()).willReturn(list);
+
+        mockMvc.perform(get("/api/categories"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("카테고리 전체 조회 성공"))
+                .andExpect(jsonPath("$.data[0].categoryName").value("문학"));
+    }
+
+    @Test
+    @DisplayName("카테고리 단건 조회 성공")
+    void getCategoryById() throws Exception {
+        Long id = 1L;
+        CategoryResponseDto dto = new CategoryResponseDto(id, "문학", "문학 설명");
+
+        given(categoryService.getCategoryById(id)).willReturn(dto);
+
+        mockMvc.perform(get("/api/categories/{id}", id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("카테고리 단건 조회 성공"))
+                .andExpect(jsonPath("$.data.categoryName").value("문학"));
+    }
+}

--- a/src/test/java/com/walkbook/demo/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/walkbook/demo/repository/CategoryRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.walkbook.demo.repository;
+
+import com.walkbook.demo.domain.Category;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("카테고리 저장 및 조회")
+    void saveAndFindById() {
+        // given
+        Category saved = categoryRepository.save(
+                new Category(null, "문학", "소설, 시, 에세이 등 문학 작품을 포함")
+        );
+
+        // when
+        Optional<Category> found = categoryRepository.findById(saved.getCategoryId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getCategoryName()).isEqualTo("문학");
+    }
+}

--- a/src/test/java/com/walkbook/demo/service/CategoryServiceImplTest.java
+++ b/src/test/java/com/walkbook/demo/service/CategoryServiceImplTest.java
@@ -1,0 +1,56 @@
+package com.walkbook.demo.service;
+
+import com.walkbook.demo.domain.Category;
+import com.walkbook.demo.dto.response.CategoryResponseDto;
+import com.walkbook.demo.error.BusinessException;
+import com.walkbook.demo.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static com.walkbook.demo.error.ExceptionCode.CATEGORY_EMPTY;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceImplTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    @Test
+    @DisplayName("카테고리 전체 조회 성공")
+    void getAllCategories() {
+        // given
+        Category c = new Category(1L, "문학", "소설, 시, 에세이 등 문학 작품을 포함");
+        given(categoryRepository.findAll()).willReturn(List.of(c));
+
+        // when
+        List<CategoryResponseDto> result = categoryService.getAllCategories();
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCategoryName()).isEqualTo("문학");
+    }
+
+    @Test
+    @DisplayName("카테고리 조회 시 존재하지 않을 경우 예외 발생")
+    void getCategoryNotFound() {
+        // given
+        Long id = 999L;
+        given(categoryRepository.findById(id)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.getCategory(id))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(CATEGORY_EMPTY.getMessage());
+    }
+}


### PR DESCRIPTION
## 📍 예외 메시지 기반 테스트 통과를 위해 `BusinessException`에  `super(exceptionCode.getMessage())` 추가
- 테스트 코드에서 `assertThatThrownBy().hasMessageContaining(...)` 사용 시
  `BusinessException`의 메시지가 null로 인식되어 검증 실패 발생
- `RuntimeException`의 `getMessage()`가 메시지를 반환할 수 있도록 super(...) 호출 추가
- 기존 Postman 환경에서는 예외 메시지를 JSON 응답 바디에 수동 전달했기 때문에 문제 없었음

🔹Postman 결과
- 수정 전
![image](https://github.com/user-attachments/assets/c1d9dc81-6726-46d6-8cf8-3682541d74c4)
- 수정 후
![image](https://github.com/user-attachments/assets/79b701a4-3981-48f1-95f3-e2e4ec696577)

-----
## 📍테스트 코드 결과
- 컨트롤러
![image](https://github.com/user-attachments/assets/5bca505b-db29-42b6-9a4f-2b6e72f1daca)

- 서비스
![image](https://github.com/user-attachments/assets/d2fb1c07-6aae-49fb-8c51-6d513f9264e6)

- 레파지토리
![image](https://github.com/user-attachments/assets/15e501da-6fa6-4646-bf19-8cfc98115e35)
